### PR TITLE
add current user and group to docker command for permission handling

### DIFF
--- a/.whoNeedsInstalls
+++ b/.whoNeedsInstalls
@@ -1,7 +1,7 @@
 # no more pesky installs and dependency conflicts with those handy aliases - put in .zshrc / .bashrc or whatever shell you use by default
 # feel free to extend and/or update
 
-DOCKER_SCOPE='docker run --rm -it --workdir /bind -v "$PWD":/bind '
+DOCKER_SCOPE='docker run --rm -it -u $(id -u):$(id -g) --workdir /bind -v "$PWD":/bind '
 alias node="$DOCKER_SCOPE node:20-alpine3.19"
 alias npm="$DOCKER_SCOPE node:20-alpine3.19 npm"
 alias bun="$DOCKER_SCOPE oven/bun:1-alpine"


### PR DESCRIPTION
If I create a file or even a project with the existing variant via composer or php, this automatically belongs to root, which leads to authorization problems. 

With the change, we now add the executing user:group, so that the user can continue working directly with the data without having to rewrite it to himself first.